### PR TITLE
Add support for decoding with meta

### DIFF
--- a/NimbleExtension.xcodeproj/project.pbxproj
+++ b/NimbleExtension.xcodeproj/project.pbxproj
@@ -191,7 +191,7 @@
 				49BAA00C2315313400C7D156 /* JSONMapper */,
 				900F6B87230CE5110018D22C /* Views */,
 				900F6B86230CE5000018D22C /* Extensions */,
-				9E093CB0231393F0005B2460 /* TypeAlias */,
+				9E093CB0231393F0005B2460 /* Typealiases */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -260,13 +260,13 @@
 			path = SourcesTests;
 			sourceTree = "<group>";
 		};
-		9E093CB0231393F0005B2460 /* TypeAlias */ = {
+		9E093CB0231393F0005B2460 /* Typealiases */ = {
 			isa = PBXGroup;
 			children = (
 				9E093CB12313940D005B2460 /* Callback.swift */,
 				9E093CB323139453005B2460 /* CompletionHandler.swift */,
 			);
-			path = TypeAlias;
+			path = Typealiases;
 			sourceTree = "<group>";
 		};
 		BDDFBCA3758B732C3B82DED2 /* Pods */ = {

--- a/NimbleExtension/Sources/JSONMapper/JSONAPIDecoder.swift
+++ b/NimbleExtension/Sources/JSONMapper/JSONAPIDecoder.swift
@@ -8,7 +8,6 @@ import Foundation
 
 public class JSONAPIDecoder: JSONDecoder {
     
-    // MARK: - private helpers
     private typealias ResourceDictionary = [ResourceIdentifier: Resource]
 
     public override func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable {
@@ -26,6 +25,12 @@ public class JSONAPIDecoder: JSONDecoder {
             throw errors
         }
     }
+    
+}
+
+// MARK: - Private
+    
+extension JSONAPIDecoder {
     
     private func decode<T: Decodable>(_ meta: JSON, into type: T.Type) throws -> T {
         let data = try JSONEncoder().encode(meta)

--- a/NimbleExtension/Sources/Typealiases/Callback.swift
+++ b/NimbleExtension/Sources/Typealiases/Callback.swift
@@ -1,9 +1,9 @@
 //
-//  CompletionHandler.swift
+//  Callback.swift
 //  NimbleExtension
 //
 //  Created by Issarapong Poesua on 8/26/19.
 //  Copyright © 2019 Nimble. All rights reserved.
 //
 
-typealias CompletionHandler = (() -> Void)
+public typealias Callback<T> = ((T) -> Void)

--- a/NimbleExtension/Sources/Typealiases/CompletionHandler.swift
+++ b/NimbleExtension/Sources/Typealiases/CompletionHandler.swift
@@ -1,9 +1,9 @@
 //
-//  Callback.swift
+//  CompletionHandler.swift
 //  NimbleExtension
 //
 //  Created by Issarapong Poesua on 8/26/19.
 //  Copyright © 2019 Nimble. All rights reserved.
 //
 
-typealias Callback<T> = ((T) -> Void)
+public typealias CompletionHandler = (() -> Void)


### PR DESCRIPTION
### **What Happened**

Since our `JSONAPIDecoder` currently supports only normal data decoding, we need to add support for meta type as well.

Also, exposed `CompletionHandler` and `Callback` type aliases public since they were set as internal 😆

### **Insight**

We're gonna use it like this
```swift
decoder.decodeWithMeta(value: SomeModel.self, meta: ModelForMeta.self, from: data)
```
but in some case where we don't wanna create a model for meta (let's say it contains only one key or stuff like that). We could go with:
```swift
let (model, meta) = decoder.decodeWithMeta(value: SomeModel.self, meta: JSON.self, from: data)
let totalScore = meta["total_score"]
```