### PR TITLE
Fix no attributes issue for JSONAPIDecoder

### DIFF
--- a/NimbleExtension/Sources/JSONMapper/JSONAPIDecoder.swift
+++ b/NimbleExtension/Sources/JSONMapper/JSONAPIDecoder.swift
@@ -99,9 +99,7 @@ extension JSONAPIDecoder {
     
     private func resolvedAttributes(of resource: Resource,
                                     including includedDictionary: ResourceDictionary) throws -> JSON? {
-        guard var attributes = resource.attributes?.nested else {
-            throw Errors.JSONAPIDecodingError.unableToDecode(reason: "Empty optional")
-        }
+        var attributes = resource.attributes?.nested ?? [:]
         attributes[Resource.CodingKeys.id.rawValue] = .string(resource.id)
         attributes[Resource.CodingKeys.type.rawValue] = .string(resource.type)
 


### PR DESCRIPTION
### What happened

@tamv263 found out that there was an issue with our `JSONAPIDecoder` where it couldn't decode `Resource` object that doesn't have `attributes`.

### Insight

According to **jsonapi.org** documentation, it's possible that a resource object might not have `attributes`

![](https://i.imgur.com/yGTd0KR.png)