### PR TITLE
As an iOS developer, I can encode a model into a dictionary

### DIFF
--- a/NimbleExtension.xcodeproj/project.pbxproj
+++ b/NimbleExtension.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		9D88926164156FD8AEEC4081 /* Pods_NimbleExtensionTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64A44437D89D07FD927FE67A /* Pods_NimbleExtensionTests.framework */; };
 		9E093CB22313940D005B2460 /* Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E093CB12313940D005B2460 /* Callback.swift */; };
 		9E093CB423139453005B2460 /* CompletionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E093CB323139453005B2460 /* CompletionHandler.swift */; };
+		C66F45912563BFA400579408 /* Encodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66F45902563BFA400579408 /* Encodable+Dictionary.swift */; };
 		EC2209B0231781EB00F49979 /* UICollectionView+RegisterReusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2209AF231781EB00F49979 /* UICollectionView+RegisterReusable.swift */; };
 		EC2209B22317853F00F49979 /* UICollectionView+DequeueReusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2209B12317853F00F49979 /* UICollectionView+DequeueReusable.swift */; };
 		EC2209B423178B6E00F49979 /* UIEdgeInsets+Initializing.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2209B323178B6E00F49979 /* UIEdgeInsets+Initializing.swift */; };
@@ -81,6 +82,7 @@
 		9E093CB12313940D005B2460 /* Callback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Callback.swift; sourceTree = "<group>"; };
 		9E093CB323139453005B2460 /* CompletionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionHandler.swift; sourceTree = "<group>"; };
 		ACBBC6CB3BF89013B8AB2C39 /* Pods_NimbleExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NimbleExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C66F45902563BFA400579408 /* Encodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Dictionary.swift"; sourceTree = "<group>"; };
 		EC2209AF231781EB00F49979 /* UICollectionView+RegisterReusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+RegisterReusable.swift"; sourceTree = "<group>"; };
 		EC2209B12317853F00F49979 /* UICollectionView+DequeueReusable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+DequeueReusable.swift"; sourceTree = "<group>"; };
 		EC2209B323178B6E00F49979 /* UIEdgeInsets+Initializing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+Initializing.swift"; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 			isa = PBXGroup;
 			children = (
 				49BAA01A2315313400C7D156 /* Optional+Extras.swift */,
+				C66F45902563BFA400579408 /* Encodable+Dictionary.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 				EC4EEB1D2320BB9D008F97DB /* UIView+RoundedCorners.swift in Sources */,
 				900F6B8F230CE5E20018D22C /* Bundle+Version.swift in Sources */,
 				49BAA0252315313500C7D156 /* Relationship.swift in Sources */,
+				C66F45912563BFA400579408 /* Encodable+Dictionary.swift in Sources */,
 				49BAA0202315313500C7D156 /* Link.swift in Sources */,
 				49BAA0232315313500C7D156 /* Resource.swift in Sources */,
 				900F6B8C230CE54E0018D22C /* UITableView+DequeueReusable.swift in Sources */,

--- a/NimbleExtension/Sources/JSONMapper/Extensions/Encodable+Dictionary.swift
+++ b/NimbleExtension/Sources/JSONMapper/Extensions/Encodable+Dictionary.swift
@@ -1,0 +1,17 @@
+//
+//  Encodable+Dictionary.swift
+//  NimbleExtension
+//
+//  Created by Tam Nguyen on 11/17/20.
+//  Copyright © 2020 Nimble. All rights reserved.
+//
+
+import Foundation
+
+public extension Encodable {
+
+    var dictionary: [String: Any]? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
+    }
+}

--- a/NimbleExtension/Sources/JSONMapper/Extensions/Encodable+Dictionary.swift
+++ b/NimbleExtension/Sources/JSONMapper/Extensions/Encodable+Dictionary.swift
@@ -12,6 +12,8 @@ public extension Encodable {
 
     var dictionary: [String: Any]? {
         guard let data = try? JSONEncoder().encode(self) else { return nil }
-        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap { $0 as? [String: Any] }
+        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap {
+            $0 as? [String: Any]
+        }
     }
 }

--- a/NimbleExtension/Sources/JSONMapper/Extensions/Encodable+Dictionary.swift
+++ b/NimbleExtension/Sources/JSONMapper/Extensions/Encodable+Dictionary.swift
@@ -10,10 +10,12 @@ import Foundation
 
 public extension Encodable {
 
-    var dictionary: [String: Any]? {
-        guard let data = try? JSONEncoder().encode(self) else { return nil }
-        return (try? JSONSerialization.jsonObject(with: data, options: .allowFragments)).flatMap {
-            $0 as? [String: Any]
+    func toDictionary(_ encoder: JSONEncoder = JSONEncoder()) -> [String: Any] {
+        guard let dictionary = try? JSONSerialization.jsonObject(
+            with: encoder.encode(self), options: .allowFragments
+        ) as? [String: Any] else {
+            return [:]
         }
+        return dictionary
     }
 }


### PR DESCRIPTION
## What happened

- Add dictionary to Encodable extension 
 
## Insight

- In current request, we have to create a dictionary to map one by one in parameters like example below:
```
var requestParameters: [String: Any] = [
    "first_name": parameters.firstName,
    "last_name": parameters.lastName,
    "nationality_id": parameters.nationality,
    "date_of_birth": parameters.dateOfBirth,
    "mobile": parameters.mobile,
    "mobile_country": parameters.mobileCountryCode,
    "otp_request_id": parameters.oTPRequestId,
    "marketing_consent": parameters.hasGivenMarketingConsent,
    "tc": parameters.hasGivenTermsAndConditionConsent,
    "consentFlag": parameters.hasGivenMarketingConsent,
    "consentVersion": parameters.consentVersion,
    "pin": parameters.pinCode
]
RequestConfiguration(
    method: .post,
    url: url(forEndpoint: "accounts"),
    parameters: requestParameters
)
```
 
## Proof Of Work

If we use swift's codable, we can encode a `model` into a `dictionary` quickly

```
RequestConfiguration(
    method: .post,
    url: url(forEndpoint: accounts),
    parameters: model.dictionary
)
```
