### PR TITLE
[Feature] Add transparent present cover view

### DIFF
--- a/NimbleExtension.podspec
+++ b/NimbleExtension.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |spec|
   spec.name         = 'NimbleExtension'
   spec.summary      = 'Swifter Swift development.'
-  spec.version      = '0.1.0'
+  spec.version      = '0.1.1'
   spec.license      = { :type => 'MIT' }
   spec.homepage     = 'https://github.com/nimblehq/NimbleExtension'
   spec.authors      = { 'Nimble' => 'dev@nimblehq.co' }
   spec.source       = { :git => 'https://github.com/nimblehq/NimbleExtension', :branch => 'master' }
   spec.source_files = 'NimbleExtension/Sources/**/*.swift'
-  spec.ios.deployment_target  = '8.0'
+  spec.ios.deployment_target  = '13.0'
 end

--- a/NimbleExtension/Sources/Views/BottomSheetTransparentView.swift
+++ b/NimbleExtension/Sources/Views/BottomSheetTransparentView.swift
@@ -27,14 +27,14 @@ import SwiftUI
 
 public struct PresentCoverTransparentView: UIViewRepresentable {
 
-    private let uiHostingViewCount: Int
+    private let maxUIHostingViewsToTraverse: Int
 
-    public init(uiHostingViewCount: Int = 2) {
-        self.uiHostingViewCount = uiHostingViewCount
+    public init(maxUIHostingViewsToTraverse: Int = 2) {
+        self.maxUIHostingViewsToTraverse = maxUIHostingViewsToTraverse
     }
 
     public func makeUIView(context: Context) -> UIView {
-        return PresentCoverTransparentBackgroundView(uiHostingViewCount: uiHostingViewCount)
+        return PresentCoverTransparentBackgroundView(maxUIHostingViewsToTraverse: maxUIHostingViewsToTraverse)
     }
 
     public func updateUIView(
@@ -46,10 +46,10 @@ public struct PresentCoverTransparentView: UIViewRepresentable {
 public class PresentCoverTransparentBackgroundView: UIView {
 
     private let uiHostingViewName = "_UIHostingView"
-    private let uiHostingViewCount: Int
+    private let maxUIHostingViewsToTraverse: Int
 
-    public init(uiHostingViewCount: Int) {
-        self.uiHostingViewCount = uiHostingViewCount
+    public init(maxUIHostingViewsToTraverse: Int) {
+        self.maxUIHostingViewsToTraverse = maxUIHostingViewsToTraverse
         super.init(frame: .zero)
     }
 
@@ -59,25 +59,25 @@ public class PresentCoverTransparentBackgroundView: UIView {
 
     override public func didMoveToWindow() {
         super.didMoveToWindow()
-        var superview = superview
-        var traversedUIHostingView = 0
-        while superview != nil && traversedUIHostingView < uiHostingViewCount {
-            if superview?.backgroundColor != .clear {
-                superview?.backgroundColor = .clear
-                superview?.isOpaque = true
+        var currentSuperview = superview
+        var traversedCount = 0
+        while let superview = currentSuperview, traversedCount < maxUIHostingViewsToTraverse {
+            if superview.backgroundColor != .clear {
+                superview.backgroundColor = .clear
+                superview.isOpaque = true
             }
             if String(describing: superview).contains(uiHostingViewName) {
-                traversedUIHostingView += 1
+                traversedCount += 1
             }
-            superview = superview?.superview
+            currentSuperview = superview?.superview
         }
     }
 }
 
 extension View {
 
-    public func presentCoverTransparentBackground(uiHostingViewCount: Int = 2) -> some View {
-        PresentCoverTransparentView(uiHostingViewCount: uiHostingViewCount)
+    public func presentCoverTransparentBackground(maxUIHostingViewsToTraverse: Int = 2) -> some View {
+        PresentCoverTransparentView(maxUIHostingViewsToTraverse: maxUIHostingViewsToTraverse)
             .ignoresSafeArea(.all, edges: [.top, .horizontal])
             .overlay { self }
     }

--- a/NimbleExtension/Sources/Views/BottomSheetTransparentView.swift
+++ b/NimbleExtension/Sources/Views/BottomSheetTransparentView.swift
@@ -1,0 +1,84 @@
+//
+//  PresentCoverTransparentView.swift
+//  NimbleExtension
+//
+//  Copyright (c) 2019 Nimble
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import SwiftUI
+
+public struct PresentCoverTransparentView: UIViewRepresentable {
+
+    private let uiHostingViewCount: Int
+
+    public init(uiHostingViewCount: Int = 2) {
+        self.uiHostingViewCount = uiHostingViewCount
+    }
+
+    public func makeUIView(context: Context) -> UIView {
+        return PresentCoverTransparentBackgroundView(uiHostingViewCount: uiHostingViewCount)
+    }
+
+    public func updateUIView(
+        _ uiView: UIView,
+        context: Context
+    ) {}
+}
+
+public class PresentCoverTransparentBackgroundView: UIView {
+
+    private let uiHostingViewName = "_UIHostingView"
+    private let uiHostingViewCount: Int
+
+    public init(uiHostingViewCount: Int) {
+        self.uiHostingViewCount = uiHostingViewCount
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override public func didMoveToWindow() {
+        super.didMoveToWindow()
+        var superview = superview
+        var traversedUIHostingView = 0
+        while superview != nil && traversedUIHostingView < uiHostingViewCount {
+            if superview?.backgroundColor != .clear {
+                superview?.backgroundColor = .clear
+                superview?.isOpaque = true
+            }
+            if String(describing: superview).contains(uiHostingViewName) {
+                traversedUIHostingView += 1
+            }
+            superview = superview?.superview
+        }
+    }
+}
+
+extension View {
+
+    public func presentCoverTransparentBackground(uiHostingViewCount: Int = 2) -> some View {
+        PresentCoverTransparentView(uiHostingViewCount: uiHostingViewCount)
+            .ignoresSafeArea(.all, edges: [.top, .horizontal])
+            .overlay { self }
+    }
+}


### PR DESCRIPTION
## What happened 👀

- Add `PresentCoverTransparentView` to present a cover view with transparent background.
- Update iOS version to 13 to support SwiftUI.
- Update podspec to 0.1.1.

## Insight 📝

- The new view is meant to be used with `FlowStacks.presentCover` or `UIKit. modalPresentationStyle = .presentCover`.

### What it does

When presenting a .presentCover screen by FlowStacks, FlowStacks creates a `UIHostingView` that contains views with background color.

<img width="640" alt="Screenshot 2567-08-28 at 17 21 01" src="https://github.com/user-attachments/assets/a3535b8e-6e1a-438f-a6e2-97440f676ea7">

To present a view with no background color, these are set on the views
```
backgroundColor = .clear
isOpaque = true
```

<img width="766" alt="Screenshot 2567-08-28 at 17 21 57" src="https://github.com/user-attachments/assets/7a1b126e-1116-4106-847f-b9030310b0fe">

### Why user `.presentCover`

`.presentCover` guaranteed that the view is present above all existing views. To visualize this clearer, alternative are discussed:
- `.overlay`: Overlay lives on the current view and does not translate to other views. Overlay is also order dependent when declare
```
Text("AAA")
.overlay { Text("BBB") }
.overlay { Text("CCC") } // CCC is always on top of BBB
```
- `.fullScreenCover`: Lives on the current view and does not translate to other views. Can have only on active `fullScreenCover` at a time. Use `UIHostingView` and require this library. 

## Proof Of Work 📹

Example usage:

```
FlowStack($path, withNavigation: true) {
            HomeView()
                .flowDestination(for: Int.self, destination: { number in
                    NumberView(number: number)
                        .frame(width: 200, height: 200)
                        .background(.black.opacity(0.4))
                        .cornerRadius(20)
                        .presentCoverTransparentBackground()
                })
        }
```

https://github.com/user-attachments/assets/2e986a50-1cb0-4735-aed7-fe2927599a67



