### PR TITLE
[Chore] Update Swift tools version and minimum platform requirements in Package.swift

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+//  swift-tools-version: 5.8
 //  Package.swift
 //  NimbleExtension
 //
@@ -10,7 +10,7 @@ import PackageDescription
 let package = Package(
     name: "NimbleExtension",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
+        .iOS(.v15), .macOS(.v11), .tvOS(.v12), .watchOS(.v4)
     ],
     products: [
         .library(name: "NimbleExtension", targets: ["NimbleExtension"])


### PR DESCRIPTION
## What happened 👀

This pull request updates the Swift tools version and adjusts the minimum deployment targets across supported platforms in Package.swift:

- Updated swift-tools-version from 5.0 to 5.8

Raised platform deployment targets:

- iOS: from .v8 → .v15

- macOS: from .v10_10 → .v11

- tvOS: from .v9 → .v12

- watchOS: from .v2 → .v4

Additionally, .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata was updated automatically due to Xcode's workspace changes.

## Insight 📝

This update is necessary because the code now uses SwiftUI APIs that require newer iOS versions:

- The use of .overlay(alignment:) requires iOS 15.0+

- .ignoresSafeArea(edges:) with specific edges (like .top, .horizontal) requires iOS 14.0+

- View itself is only available starting from iOS 13.0

Attempting to build with the older platform targets caused compilation failures, as shown in the attached Xcode screenshot. Therefore, raising the minimum deployment targets ensures compatibility and prevents build-time errors.

<img width="1519" alt="Screenshot 2025-06-02 at 11 46 43" src="https://github.com/user-attachments/assets/1407cf6b-5a61-4e30-b768-6c5a8ea28b0e" />


## Proof Of Work 📹

**Build successfully**

<img width="1519" alt="Screenshot 2025-06-02 at 11 47 08" src="https://github.com/user-attachments/assets/2e41126a-ad0f-40c4-b4c0-3ab0911fceaf" />